### PR TITLE
Fix azure support

### DIFF
--- a/reference-azure-support.adoc
+++ b/reference-azure-support.adoc
@@ -27,48 +27,47 @@ https://docs.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview[Learn
 
 == Supported Azure regions
 
-BlueXP tiering supports tiering to any storage account in any region that can be accessed via the Connector.
 
-//BlueXP tiering supports the following Azure regions.
-//
-//=== Africa
-//
-//* South Africa North
-//
-//=== Asia Pacific
-//
-//* Australia East
-//* Australia Southeast
-//* East Asia
-//* Japan East
-//* Japan West
-//* Korea Central
-//* Korea South
-//* Southeast Asia
-//
-//=== Europe
-//
-//* France Central
-//* Germany West Central
-//* Germany North
-//* North Europe
-//* UK South
-//* UK West
-//* West Europe
-//
-//=== North America
-//
-//* Canada Central
-//* Canada East
-//* Central US
-//* East US
-//* East US 2
-//* North Central US
-//* South Central US
-//* West US
-//* West US 2
-//* West Central US
-//
-//=== South America
-//
-//* Brazil South
+BlueXP tiering supports the following Azure regions. Azure China regions are not supported as destinations for tiering. 
+
+=== Africa
+
+* South Africa North
+
+=== Asia Pacific
+
+* Australia East
+* Australia Southeast
+* East Asia
+* Japan East
+* Japan West
+* Korea Central
+* Korea South
+* Southeast Asia
+
+=== Europe
+
+* France Central
+* Germany West Central
+* Germany North
+* North Europe
+* UK South
+* UK West
+* West Europe
+
+=== North America
+
+* Canada Central
+* Canada East
+* Central US
+* East US
+* East US 2
+* North Central US
+* South Central US
+* West US
+* West US 2
+* West Central US
+
+=== South America
+
+* Brazil South


### PR DESCRIPTION
This pull request updates the documentation for supported Azure regions in `reference-azure-support.adoc`. The most important change is the reintroduction of the detailed list of supported Azure regions for BlueXP tiering, along with a clarification about the exclusion of Azure China regions.

### Documentation updates:

* Re-added the detailed list of supported Azure regions for BlueXP tiering, organized by continent, and clarified that Azure China regions are not supported as destinations for tiering.