### PR TITLE
azure support china

### DIFF
--- a/reference-azure-support.adoc
+++ b/reference-azure-support.adoc
@@ -28,46 +28,5 @@ https://docs.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview[Learn
 == Supported Azure regions
 
 
-BlueXP tiering supports the following Azure regions. Azure China regions are not supported as destinations for tiering. 
+BlueXP tiering is supported in all Azure Regions except for China, where Microsoft Azure operated by 21Vianet.
 
-=== Africa
-
-* South Africa North
-
-=== Asia Pacific
-
-* Australia East
-* Australia Southeast
-* East Asia
-* Japan East
-* Japan West
-* Korea Central
-* Korea South
-* Southeast Asia
-
-=== Europe
-
-* France Central
-* Germany West Central
-* Germany North
-* North Europe
-* UK South
-* UK West
-* West Europe
-
-=== North America
-
-* Canada Central
-* Canada East
-* Central US
-* East US
-* East US 2
-* North Central US
-* South Central US
-* West US
-* West US 2
-* West Central US
-
-=== South America
-
-* Brazil South


### PR DESCRIPTION
This pull request updates the documentation for supported Azure regions in the `reference-azure-support.adoc` file. The change simplifies the description of BlueXP tiering support by replacing a detailed list of regions with a broader statement.

### Documentation update:

* [`reference-azure-support.adoc`](diffhunk://#diff-def8724f7bdcde4885bc7f539cae598984aa7c036bf5a5c2a4e818a8330f8136L31-L73): Replaced the detailed list of supported Azure regions with a concise statement indicating that BlueXP tiering is supported in all Azure regions except for China, where Microsoft Azure is operated by 21Vianet.