### PR TITLE
Licensing email

### DIFF
--- a/task-licensing-cloud-tiering.adoc
+++ b/task-licensing-cloud-tiering.adoc
@@ -101,8 +101,8 @@ Bring-your-own licenses from NetApp provide 1-, 2-, or 3-year terms. The BYOL *B
 
 If you don't have a BlueXP tiering license, contact us to purchase one:
 
-* mailto:ng-cloud-tiering@netapp.com?subject=Licensing[Send email to purchase a license].
-* Click the chat icon in the lower-right of BlueXP to request a license.
+* Contact your NetApp sales representative
+* Contact NetApp support.
 
 Optionally, if you have an unassigned node-based license for Cloud Volumes ONTAP that you won't be using, you can convert it to a BlueXP tiering license with the same dollar-equivalence and the same expiration date. https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-manage-node-licenses.html#exchange-unassigned-node-based-licenses[Go here for details^].
 


### PR DESCRIPTION
This pull request updates the instructions for purchasing or obtaining a BlueXP tiering license in the `task-licensing-cloud-tiering.adoc` file. The changes clarify the contact methods and improve the user guidance.

Licensing instructions update:

* Replaced the email and chat options for purchasing a license with instructions to contact a NetApp sales representative or NetApp support. (`task-licensing-cloud-tiering.adoc`, [task-licensing-cloud-tiering.adocL104-R105](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L104-R105))