### PR TITLE
Metrocluster usage

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -12,7 +12,7 @@ indexpage:
           url: whats-new.html
         - title: Set up licensing
           url: task-licensing-cloud-tiering.html
-    - title: Tier on-prem ONTAP data to the cloud
+    - title: Tier on-premises ONTAP data to the cloud
       links:
         - title: Tier to Amazon S3
           url: task-tiering-onprem-aws.html

--- a/concept-cloud-tiering.adoc
+++ b/concept-cloud-tiering.adoc
@@ -27,7 +27,7 @@ https://bluexp.netapp.com/cloud-tiering-service-tco[Use the BlueXP tiering TCO c
 
 BlueXP tiering offers automation, monitoring, reports, and a common management interface:
 
-* Automation makes it easier to set up and manage data tiering from on-prem ONTAP clusters to the cloud
+* Automation makes it easier to set up and manage data tiering from on-premises ONTAP clusters to the cloud
 * You can choose the default cloud provider storage class/access tier, or use lifecycle management to assign a more cost-effective tier to older tiered data 
 * You can create connections to additional object stores that can be used for other aggregates in your cluster
 * Using the UI you can drag object stores to an aggregate for tiering and for FabricPool mirroring
@@ -108,7 +108,7 @@ Annual contracts are not currently supported when tiering to Google CLoud.
 
 === Bring your own license
 
-Bring your own license by purchasing a *BlueXP tiering* license from NetApp (previously known as a "Cloud Tiering" license). You can purchase 1-, 2-, or 3-year term licenses and specify any amount of tiering capacity (starting at a minimum of 10 TiB). The BYOL BlueXP tiering license is a _floating_ license that you can use across multiple on-premises ONTAP clusters. The total tiering capacity that you define in your BlueXP tiering license can be used by all of your on-prem clusters.
+Bring your own license by purchasing a *BlueXP tiering* license from NetApp (previously known as a "Cloud Tiering" license). You can purchase 1-, 2-, or 3-year term licenses and specify any amount of tiering capacity (starting at a minimum of 10 TiB). The BYOL BlueXP tiering license is a _floating_ license that you can use across multiple on-premises ONTAP clusters. The total tiering capacity that you define in your BlueXP tiering license can be used by all of your on-premises clusters.
 
 After you purchase a BlueXP tiering license, you'll need use the BlueXP digital wallet in BlueXP to add the license. link:task-licensing-cloud-tiering.html#use-a-bluexp-tiering-byol-license[See how to use a BlueXP tiering BYOL license].
 
@@ -126,7 +126,7 @@ image:diagram_cloud_tiering.png["An architecture image that shows the BlueXP tie
 
 At a high level, BlueXP tiering works like this:
 
-. You discover your on-prem cluster from BlueXP.
+. You discover your on-premises cluster from BlueXP.
 . You set up tiering by providing details about your object storage, including the bucket/container, a storage class or access tier, and lifecycle rules for the tiered data.
 . BlueXP configures ONTAP to use the object storage provider and discovers the amount of active and inactive data on the cluster.
 . You choose the volumes to tier and the tiering policy to apply to those volumes.

--- a/concept-cloud-tiering.adoc
+++ b/concept-cloud-tiering.adoc
@@ -15,7 +15,9 @@ summary: NetApp's BlueXP tiering service extends your data center to the cloud b
 [.lead]
 NetApp's BlueXP tiering service extends your data center to the cloud by automatically tiering inactive data from on-premises ONTAP clusters to object storage. This frees valuable space on the cluster for more workloads, without making changes to the application layer. BlueXP tiering can reduce costs in your data center and enables you to switch from a CAPEX model to an OPEX model.
 
-The BlueXP tiering service leverages the capabilities of _FabricPool_. FabricPool is a NetApp Data Fabric technology that enables automated tiering of data to low-cost object storage. Active (hot) data remains on the local tier (on-premises ONTAP aggregates), while inactive (cold) data is moved to the cloud tier -- all while preserving ONTAP data efficiencies.
+The BlueXP tiering service uses _FabricPool_. FabricPool is a NetApp Data Fabric technology that enables automated tiering of data to low-cost object storage. Active (hot) data remains on the local tier (on-premises ONTAP aggregates), while inactive (cold) data is moved to the cloud tier -- all while preserving ONTAP data efficiencies.
+
+Suggestion: Active (hot) data stays on the local tier (on-premises ONTAP aggregates), while inactive (cold) data is moved to the cloud tier -- keeping ONTAP data efficient.
 
 Originally supported on AFF, FAS, and ONTAP Select systems with all-SSD aggregates, starting with ONTAP 9.8 you can tier data from aggregates consisting of HDDs in addition to high-performance SSDs. See https://docs.netapp.com/us-en/ontap/fabricpool/requirements-concept.html[the considerations and requirements for using FabricPool^] for details.
 

--- a/faq-cloud-tiering.adoc
+++ b/faq-cloud-tiering.adoc
@@ -121,7 +121,7 @@ To get an estimate, simply add your ONTAP cluster to BlueXP and inspect it throu
 
 === How am I charged for tiering when I am using an ONTAP MetroCluster?
 
-When used in MetroCluster environments, tiering licensed capacity is applied to mirrored buckets equally. For example, if you have a license for 100TiB of tiering, both buckets can be tiered up to 100 TiB. There is no extra charge for mirrored buckets. When tiering from unmirrored aggregates in MetroCluster environments, the BlueXP tiering license is applied as normal, and the total capacity tiered to both buckets is used. For example, if you have a license for 100TiB of tiering, both buckets can be tiered up to 50TB.
+When used in MetroCluster environments, total tiering license is applied to both clusters’ usage. For example, if you have a license for 100TiB of tiering, each cluster’s used tiering capacity contributes to the total capacity of 100TiB. 
 
 == ONTAP
 

--- a/faq-cloud-tiering.adoc
+++ b/faq-cloud-tiering.adoc
@@ -103,7 +103,7 @@ However, if you have a PAYGO marketplace subscription to the _BlueXP - Deploy & 
 
 No, it does not.
 
-=== Is rehydration of on-prem systems subject to the egress cost charged by the cloud providers?
+=== Is rehydration of on-premises systems subject to the egress cost charged by the cloud providers?
 
 Yes. All reads from the public cloud are subject to egress fees.
 
@@ -111,7 +111,7 @@ Yes. All reads from the public cloud are subject to egress fees.
 
 The best way to estimate how much a cloud provider will charge for hosting your data is to use their calculators: https://calculator.aws/#/[AWS], https://azure.microsoft.com/en-us/pricing/calculator/[Azure] and https://cloud.google.com/products/calculator[Google Cloud].
 
-=== Are there any extra charges by the cloud providers for reading/retrieving data from the object storage to the on-prem storage?
+=== Are there any extra charges by the cloud providers for reading/retrieving data from the object storage to the on-premises storage?
 
 Yes. Check https://aws.amazon.com/s3/pricing/[Amazon S3 Pricing], https://azure.microsoft.com/en-us/pricing/details/storage/blobs/[Block Blob Pricing], and https://cloud.google.com/storage/pricing[Cloud Storage Pricing] for additional pricing incurred with data reading/retrieving.
 
@@ -228,7 +228,7 @@ If the destination aggregate does not have an attached cloud tier, data is read 
 
 Starting with ONTAP 9.6, if the destination aggregate is using the same cloud tier as the source aggregate, the cold data does not move back to the local tier.
 
-=== How can I bring my tiered data back on-prem to the performance tier?
+=== How can I bring my tiered data back on-premises to the performance tier?
 
 Write back is generally performed on reads and depends on the tiering policy type. Prior to ONTAP 9.8, writing back of the entire volume can be done with a _volume move_ operation. Starting with ONTAP 9.8, the Tiering UI has options to *Bring back all data* or *Bring back active file system*. link:task-managing-tiering.html#migrating-data-from-the-cloud-tier-back-to-the-performance-tier[See how to move data back to the performance tier].
 

--- a/project.yml
+++ b/project.yml
@@ -17,7 +17,7 @@ sidebar:
       entries:
         - title: Learn about BlueXP tiering
           url: /concept-cloud-tiering.html
-        - title: Tier on-prem data to the cloud
+        - title: Tier on-premises data to the cloud
           entries:
             - title: Tier to Amazon S3
               url: /task-tiering-onprem-aws.html

--- a/reference-google-support.adoc
+++ b/reference-google-support.adoc
@@ -17,7 +17,7 @@ BlueXP tiering supports several Google Cloud storage classes and most regions.
 
 == Supported GCP storage classes
 
-When you set up data tiering to GCP from your on-premises ONTAP systems, BlueXP tiering automatically uses the _Standard_ storage class for your inactive data. BlueXP tiering can apply a lifecycle rule so the data transitions from the _Standard_ storage class to other storage classes after a certain number of days. You can choose from the following storage classes:
+When you set up data tiering to Google Cloud storage from your on-premises ONTAP systems,  tiering automatically uses the _Standard_ storage class for your inactive data. Tiering can apply a lifecycle rule so the data transitions from the _Standard_ storage class to other storage classes after a certain number of days. You can choose from the following storage classes:
 
 * Nearline
 * Coldline
@@ -25,13 +25,13 @@ When you set up data tiering to GCP from your on-premises ONTAP systems, BlueXP 
 
 If you do not choose another storage class, then the data remains in the _Standard_ storage class and no rules are applied.
 
-When you configure a BlueXP tiering lifecycle rule, you must not configure any lifecycle rules when setting up the bucket in your Google account. 
+When you configure a tiering lifecycle rule, you must not configure any lifecycle rules when setting up the bucket in your Google account. 
 
 https://cloud.google.com/storage/docs/storage-classes[Learn about Google Cloud Storage classes^].
 
 == Supported Google Cloud regions
 
-BlueXP tiering supports the following regions.
+Tiering supports the following regions.
 
 === Americas
 

--- a/task-licensing-cloud-tiering.adoc
+++ b/task-licensing-cloud-tiering.adoc
@@ -17,23 +17,23 @@ A 30-day free trial of BlueXP tiering starts when you set up tiering from your f
 
 A few notes before you read any further:
 
-* If you've already subscribed to the BlueXP subscription (PAYGO) in your cloud provider's marketplace, then you're automatically subscribed to BlueXP tiering for on-premises ONTAP systems as well. You'll see an active subscription in the BlueXP tiering *On-Premises dashboard* tab. You won't need to subscribe again. You'll see an active subscription in the BlueXP digital wallet.
+* If you've already subscribed to NetApp Intelligent Services (PAYGO) in your cloud provider's marketplace, then you're automatically subscribed to tiering for on-premises ONTAP systems as well. You'll see an active subscription in the tiering *On-Premises dashboard* tab. You won't need to subscribe again. You'll see an active subscription in the digital wallet.
 
 * The BYOL BlueXP tiering license (previously known as a "Cloud Tiering" license) is a _floating_ license that you can use across multiple on-premises ONTAP clusters in your BlueXP organization. This is different (and much easier) than in the past where you purchased a _FabricPool_ license for each cluster.
 
 * There are no charges when tiering data to StorageGRID, so neither a BYOL license or PAYGO registration is required. This tiered data doesn't count against the capacity purchased in your license.
 
-link:concept-cloud-tiering.html#pricing-and-licenses[Learn more about how licensing works for BlueXP tiering].
+link:concept-cloud-tiering.html#pricing-and-licenses[Learn more about how licensing works for tiering].
 
 == 30-day free trial
 
-If you don't have a BlueXP tiering license, a 30-day free trial of BlueXP tiering starts when you set up tiering to your first cluster. After the 30-day free trial ends, you'll need to pay for BlueXP tiering through a pay-as-you-go subscription, annual subscription, a BYOL license, or a combination.
+If you don't have a tiering license, a 30-day free trial of tiering starts when you set up tiering to your first cluster. After the 30-day free trial ends, you'll need to pay for tiering through a pay-as-you-go subscription, annual subscription, a BYOL license, or a combination.
 
 If your free trial ends and you haven't subscribed or added a license, then ONTAP no longer tiers cold data to object storage. All previously tiered data remains accessible; meaning you can retrieve and use this data. When retrieved, this data is moved back to the performance tier from the cloud. 
 
-== Use a BlueXP tiering PAYGO subscription
+== Use a NetApp Intelligent Services tiering PAYGO subscription
 
-Pay-as-you-go subscriptions from your cloud provider's marketplace enable you to license the use of Cloud Volumes ONTAP systems and many Cloud Data Services, such as BlueXP tiering.
+Pay-as-you-go subscriptions from your cloud provider's marketplace enable you to license the use of Cloud Volumes ONTAP systems and NetApp Intelligent Services, such as tiering.
 
 After you subscribe to BlueXP tiering, you can manage your subscriptions in digital wallet. link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-subscriptions.html#view-your-subscriptions[Learn how to use digital wallet.^]
 
@@ -43,9 +43,9 @@ Subscribe to BlueXP tiering from the AWS Marketplace to set up a pay-as-you-go s
 
 .Steps
 [[subscribe-aws]]
-. In BlueXP, click *Mobility > Tiering > On-Premises Dashboard*.
+. In BlueXP, select *Mobility > Tiering > On-Premises Dashboard*.
 
-. In the _Marketplace subscriptions_ section, click *Subscribe* under Amazon Web Services and then click *Continue*.
+. In the _Marketplace subscriptions_ section, select *Subscribe* under Amazon Web Services and then select *Continue*.
 
 . Subscribe from the https://aws.amazon.com/marketplace/pp/prodview-oorxakq6lq7m4[AWS Marketplace^], and then log back into the BlueXP website to complete the registration.
 +
@@ -59,9 +59,9 @@ Subscribe to BlueXP tiering from the Azure Marketplace to set up a pay-as-you-go
 
 .Steps
 [[subscribe-azure]]
-. In BlueXP, click *Mobility > Tiering > On-Premises Dashboard*.
+. In BlueXP, select *Mobility > Tiering > On-Premises Dashboard*.
 
-. In the _Marketplace subscriptions_ section, click *Subscribe* under Microsoft Azure and then click *Continue*.
+. In the _Marketplace subscriptions_ section, select *Subscribe* under Microsoft Azure and then select *Continue*.
 
 . Subscribe from the https://azuremarketplace.microsoft.com/en-us/marketplace/apps/netapp.cloud-manager?tab=Overview[Azure Marketplace^], and then log back into the BlueXP website to complete the registration.
 +
@@ -75,9 +75,9 @@ Subscribe to BlueXP tiering from the Google Cloud Marketplace to set up a pay-as
 
 .Steps
 [[subscribe-gcp]]
-. In BlueXP, click *Mobility > Tiering > On-Premises Dashboard*.
+. In BlueXP, select *Mobility > Tiering > On-Premises Dashboard*.
 
-. In the _Marketplace subscriptions_ section, click *Subscribe* under Google Cloud and then click *Continue*.
+. In the _Marketplace subscriptions_ section, select *Subscribe* under Google Cloud and then select *Continue*.
 
 . Subscribe from the https://console.cloud.google.com/marketplace/details/netapp-cloudmanager/cloud-manager?supportedpurview=project[Google Cloud Marketplace^], and then log back into the BlueXP website to complete the registration.
 +
@@ -87,7 +87,7 @@ video::373b96de-3691-4d84-b3f3-b05101161638[panopto, title="Subscribe to BlueXP 
 
 == Use an annual contract
 
-Pay for BlueXP tiering annually by purchasing an annual contract. Annual contracts are available in 1-, 2-, or 3-year terms.
+Pay for tiering annually by purchasing an annual contract. Annual contracts are available in 1-, 2-, or 3-year terms.
 
 When tiering inactive data to AWS, you can subscribe to an annual contract from the https://aws.amazon.com/marketplace/pp/prodview-q7dg6zwszplri[AWS Marketplace page^]. If you want to use this option, set up your subscription from the Marketplace page and then https://docs.netapp.com/us-en/bluexp-setup-admin/task-adding-aws-accounts.html#associate-an-aws-subscription[associate the subscription with your AWS credentials^].
 
@@ -97,7 +97,7 @@ Annual contracts are not currently supported when tiering to Google Cloud.
 
 == Use a BlueXP tiering BYOL license
 
-Bring-your-own licenses from NetApp provide 1-, 2-, or 3-year terms. The BYOL *BlueXP tiering* license (previously known as a "Cloud Tiering" license) is a _floating_ license that you can use across multiple on-premises ONTAP clusters in your BlueXP organization. The total tiering capacity defined in your BlueXP tiering license is shared among *all* of your on-prem clusters, making initial licensing and renewal easy. The minimum capacity for a tiering BYOL license starts at 10 TiB.
+Bring-your-own licenses from NetApp provide 1-, 2-, or 3-year terms. The BYOL *BlueXP tiering* license (previously known as a "Cloud Tiering" license) is a _floating_ license that you can use across multiple on-premises ONTAP clusters in your BlueXP organization. The total tiering capacity defined in your BlueXP tiering license is shared among *all* of your on-premises clusters, making initial licensing and renewal easy. The minimum capacity for a tiering BYOL license starts at 10 TiB.
 
 If you don't have a BlueXP tiering license, contact us to purchase one:
 
@@ -106,7 +106,7 @@ If you don't have a BlueXP tiering license, contact us to purchase one:
 
 Optionally, if you have an unassigned node-based license for Cloud Volumes ONTAP that you won't be using, you can convert it to a BlueXP tiering license with the same dollar-equivalence and the same expiration date. https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-manage-node-licenses.html#exchange-unassigned-node-based-licenses[Go here for details^].
 
-You use the BlueXP digital wallet page to manage BlueXP tiering BYOL licenses. You can add new licenses and update existing licenses. link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[Learn how to use digital wallet.^]
+You use the digital wallet page to manage your licenses. You can add new licenses and update existing licenses. link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[Learn how to use digital wallet.^]
 
 === BlueXP tiering BYOL licensing starting in 2021
 
@@ -177,11 +177,11 @@ Do not configure tiering at this point.
 
 . In BlueXP tiering, link:task-managing-tiering.html#discovering-additional-clusters-from-bluexp-tiering[discover the new clusters].
 
-. From the Clusters page, click image:screenshot_horizontal_more_button.gif[More icon] for the cluster and select *Deploy License*.
+. From the Clusters page, select image:screenshot_horizontal_more_button.gif[More icon] for the cluster and select *Deploy License*.
 +
 image:screenshot_tiering_deploy_license.png[A screenshot showing how to deploy a tiering license to an ONTAP cluster.]
 
-. In the _Deploy License_ dialog, click *Deploy*.
+. In the _Deploy License_ dialog, select *Deploy*.
 +
 The child license is deployed to the ONTAP cluster.
 

--- a/task-managing-object-storage.adoc
+++ b/task-managing-object-storage.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-managing-object-storage.html
 keywords: object storage, mirror object storage, create object storage, remove object storage, swap object storage, display object storage, license
-summary: After you've configured your on-prem ONTAP clusters to tier data to a particular object storage, you can perform additional object storage tasks. You can add new object storage, mirror your tiered data to a secondary object storage, swap the primary and mirror object storage, remove a mirrored object store from an aggregate, and more.
+summary: After you've configured your on-premises ONTAP clusters to tier data to a particular object storage, you can perform additional object storage tasks. You can add new object storage, mirror your tiered data to a secondary object storage, swap the primary and mirror object storage, remove a mirrored object store from an aggregate, and more.
 ---
 
 = Managing object storage used for data tiering
@@ -13,15 +13,15 @@ summary: After you've configured your on-prem ONTAP clusters to tier data to a p
 :imagesdir: ./media/
 
 [.lead]
-After you've configured your on-prem ONTAP clusters to tier data to a particular object storage, you can perform additional object storage tasks. You can add new object storage, mirror your tiered data to a secondary object storage, swap the primary and mirror object storage, remove a mirrored object store from an aggregate, and more.
+After you've configured your on-premises ONTAP clusters to tier data to a particular object storage, you can perform additional object storage tasks. You can add new object storage, mirror your tiered data to a secondary object storage, swap the primary and mirror object storage, remove a mirrored object store from an aggregate, and more.
 
 == Viewing object stores configured for a cluster
 
-You might want to see all the object stores that have been configured for your cluster and to which aggregates they are attached. BlueXP tiering provides this information for each cluster.
+You can see all the object stores that have been configured for each cluster and to which aggregates they are attached. 
 
 .Steps
 
-. From the *Clusters* page, click the menu icon for a cluster and select *Object Store Info*.
+. From the *Clusters* page, select the menu icon for a cluster and select *Object Store Info*.
 
 . Review details about the object stores.
 +
@@ -31,13 +31,13 @@ image:screenshot_tiering_object_store_view.png["A screenshot that shows the obje
 
 == Adding a new object store
 
-You can add a new object store that will be available for aggregates in your cluster. After you create it, you can attach it to an aggregate.
+Add a new object store that you can attach to an aggregate.
 
 .Steps
 
-. From the *Clusters* page, click the menu icon for a cluster and select *Object Store Info*.
+. From the *Clusters* page, select the menu icon for a cluster and select *Object Store Info*.
 
-. From the Object Store Information page, click *Create New Object Store*.
+. From the Object Store Information page, select *Create New Object Store*.
 +
 image:screenshot_tiering_object_store_create_button.png["A screenshot showing the Create New Object Store button to create a new object store."]
 +
@@ -45,17 +45,17 @@ The object store wizard starts. The example below shows how to create an object 
 
 . *Define Object Storage Name*: Enter a name for this object storage. It must be unique from any other object storage you may be using with aggregates on this cluster.
 
-. *Select Provider*: Select the provider, for example *Amazon Web Services*, and click *Continue*.
+. *Select Provider*: Select the provider, for example *Amazon Web Services*, and select *Continue*.
 
 . Complete the steps on the *Create Object Storage* pages:
 
-.. *S3 Bucket*: Add a new S3 bucket or select an existing S3 bucket that starts with the prefix _fabric-pool_. Then enter the AWS Account ID that provides access to the bucket, select the bucket region, and click *Continue*.
+.. *S3 Bucket*: Add a new S3 bucket or select an existing S3 bucket that starts with the prefix _fabric-pool_. Then enter the AWS Account ID that provides access to the bucket, select the bucket region, and select *Continue*.
 +
 The _fabric-pool_ prefix is required because the IAM policy for the Connector enables the instance to perform S3 actions on buckets named with that exact prefix. For example, you could name the S3 bucket _fabric-pool-AFF1_, where AFF1 is the name of the cluster.
 
 .. *Storage Class Lifecycle*: BlueXP tiering manages the lifecycle transitions of your tiered data. Data starts in the _Standard_ class, but you can create a rule to apply a different storage class to the data after a certain number of days.
 +
-Select the S3 storage class that you want to transition the tiered data to and the number of days before the data is assigned to that class, and click *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Standard-IA_ class from the _Standard_ class after 45 days in object storage.
+Select the S3 storage class that you want to transition the tiered data to and the number of days before the data is assigned to that class, and select *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Standard-IA_ class from the _Standard_ class after 45 days in object storage.
 +
 If you choose *Keep data in this storage class*, then the data remains in the _Standard_ storage class and no rules are applied. link:reference-aws-support.html[See supported storage classes^].
 +
@@ -63,11 +63,11 @@ image:screenshot_tiering_lifecycle_selection_aws.png[A screenshot showing how to
 +
 Note that the lifecycle rule is applied to all objects in the selected bucket.
 
-.. *Credentials*: Enter the access key ID and secret key for an IAM user who has the required S3 permissions, and click *Continue*.
+.. *Credentials*: Enter the access key ID and secret key for an IAM user who has the required S3 permissions, and select *Continue*.
 +
 The IAM user must be in the same AWS account as the bucket that you selected or created on the *S3 Bucket* page. See the required permissions in the section about activating tiering.
 
-.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage, and click *Continue*.
+.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage, and select *Continue*.
 +
 Selecting the correct IPspace ensures that BlueXP tiering can set up a connection from ONTAP to your cloud provider's object storage.
 
@@ -87,7 +87,7 @@ When using StorageGRID as your object store in a MetroCluster configuration, bot
 
 .Steps
 
-. From the *Clusters* page, click *Advanced setup* for the selected cluster.
+. From the *Clusters* page, select *Advanced setup* for the selected cluster.
 +
 image:screenshot_tiering_advanced_setup_button.png[A screenshot showing the Advanced Setup button for a cluster.]
 
@@ -95,7 +95,7 @@ image:screenshot_tiering_advanced_setup_button.png[A screenshot showing the Adva
 +
 image:screenshot_tiering_mirror_config.png["A screenshot showing how to drag a second object store to an aggregate to create a tiering mirror."]
 
-. In the Attach Object Store dialog, click *Attach* and the second object store is attached to the aggregate.
+. In the Attach Object Store dialog, select *Attach* and the second object store is attached to the aggregate.
 +
 image:screenshot_tiering_mirror_config_complete.png["A screenshot showing a second object store attached to an aggregate."]
 
@@ -107,11 +107,11 @@ You can swap the primary and mirror object store for an aggregate. The object st
 
 .Steps
 
-. From the *Clusters* page, click *Advanced setup* for the selected cluster.
+. From the *Clusters* page, select *Advanced setup* for the selected cluster.
 +
 image:screenshot_tiering_advanced_setup_button.png[A screenshot showing the Advanced Setup button for a cluster.]
 
-. From the Advanced Setup page, click the menu icon for the aggregate and select *Swap Destinations*.
+. From the Advanced Setup page, select the menu icon for the aggregate and select *Swap Destinations*.
 +
 image:screenshot_tiering_mirror_swap.png["A screenshot showing the Swap Destination option for an aggregate."]
 
@@ -123,11 +123,11 @@ You can remove a FabricPool mirror if you no longer need to replicate to an addi
 
 .Steps
 
-. From the *Clusters* page, click *Advanced setup* for the selected cluster.
+. From the *Clusters* page, select *Advanced setup* for the selected cluster.
 +
 image:screenshot_tiering_advanced_setup_button.png[A screenshot showing the Advanced Setup button for a cluster.]
 
-. From the Advanced Setup page, click the menu icon for the aggregate and select *Unmirror Object Store*.
+. From the Advanced Setup page, select the menu icon for the aggregate and select *Unmirror Object Store*.
 +
 image:screenshot_tiering_mirror_delete.png["A screenshot showing the Unmirror Object Store option for an aggregate."]
 

--- a/task-managing-tiering.adoc
+++ b/task-managing-tiering.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-managing-tiering.html
 keywords: discover, volumes, report, hot, cold, inactive, active, capacity, used capacity, savings, health, failed
-summary: Now that you've set up data tiering from your on-prem ONTAP clusters, you can tier data from additional volumes, change a volume's tiering policy, discover additional clusters, and more.
+summary: Now that you've set up data tiering from your on-premises ONTAP clusters, you can tier data from additional volumes, change a volume's tiering policy, discover additional clusters, and more.
 ---
 
 = Managing data tiering for your clusters
@@ -13,17 +13,17 @@ summary: Now that you've set up data tiering from your on-prem ONTAP clusters, y
 :imagesdir: ./media/
 
 [.lead]
-Now that you've set up data tiering from your on-prem ONTAP clusters, you can tier data from additional volumes, change a volume's tiering policy, discover additional clusters, and more.
+Now that you've set up data tiering from your on-premises ONTAP clusters, you can tier data from additional volumes, change a volume's tiering policy, discover additional clusters, and more.
 
 == Reviewing tiering info for a cluster
 
-You might want to see how much data is in the cloud tier and how much data is on disks. Or, you might want to see the amount of hot and cold data on the cluster's disks. BlueXP tiering provides this information for each cluster.
+You can view how much data is in the cloud tier and how much data is on disks. You can also see the amount of hot and cold data on the cluster's disks for each cluster that you manage with BlueXP tiering. This information is available on the _Clusters_ page.
 
 .Steps
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click the menu icon image:icon-action.png[Actions icon] for a cluster and select *Cluster info*.
+. From the *Clusters* page, select  the menu icon image:icon-action.png[Actions icon] for a cluster and select *Cluster info*.
 +
 image:screenshot_tiering_cluster_info_button.png[A screenshot of selecting the Cluster Info button from the Clusters page.]
 
@@ -49,20 +49,20 @@ TIP: You don't need to configure the object storage because it was already confi
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click *Tier volumes* for the cluster.
+. From the *Clusters* page, select  *Tier volumes* for the cluster.
 +
 image:screenshot_tiering_tier_volumes_button.png[A screenshot showing how to select the Tier Volumes button for a cluster.]
 
 . On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and launch the Tiering Policy page:
 
 +
-* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and click *Configure volumes*.
-* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and click *Configure volumes*.
-* To select a single volume, click the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
+* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and select  *Configure volumes*.
+* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and select *Configure volumes*.
+* To select a single volume, select the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
 +
 image:screenshot_tiering_tier_volumes.png[A screenshot that shows how to select a single volume, multiple volume, or all volumes, and the modify selected volumes button.]
 
-. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and click *Apply*.
+. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +
@@ -80,9 +80,9 @@ Changing the tiering policy for a volume changes how ONTAP tiers cold data to ob
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click *Tier volumes* for the cluster.
+. From the *Clusters* page, select *Tier volumes* for the cluster.
 
-. Click the row for a volume, select a tiering policy, optionally adjust the cooling days, and click *Apply*.
+. Click the row for a volume, select a tiering policy, optionally adjust the cooling days, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +
@@ -96,15 +96,15 @@ The tiering policy is changed and data begins to be tiered based on the new poli
 
 == Changing the network bandwidth available to upload inactive data to object storage
 
-When you activate BlueXP tiering for a cluster, by default, ONTAP can use an unlimited amount of bandwidth to transfer the inactive data from volumes in the working environment to object storage. If you notice that tiering traffic is affecting normal user workloads, you can throttle the amount of network bandwidth that is used during the transfer. You can choose a value between 1 and 10,000 Mbps as the maximum transfer rate.
+When you activate tiering for a cluster, by default, ONTAP uses an unlimited amount of bandwidth to transfer the inactive data from volumes in the working environment to object storage. If you notice that tiering traffic is affecting normal user workloads, you can throttle the amount of network bandwidth that is used during the transfer. You can choose a value between 1 and 10,000 Mbps as the maximum transfer rate.
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click the menu icon image:icon-action.png[Actions icon] for a cluster and select *Maximum transfer rate*.
+. From the *Clusters* page, select the menu icon image:icon-action.png[Actions icon] for a cluster and select *Maximum transfer rate*.
 +
 image:screenshot_tiering_transfer_rate_button.png[A screenshot of selecting the Maximum transfer rate button from the Clusters page.]
 
-. In the _Maximum transfer rate_ page, select the *Limited* radio button and enter the maximum bandwidth that can be used, or select *Unlimited* to indicate that there is no limit. Then click *Apply*.
+. In the _Maximum transfer rate_ page, select the *Limited* radio button and enter the maximum bandwidth that can be used, or select *Unlimited* to indicate that there is no limit. Then select *Apply*.
 +
 image:screenshot_tiering_transfer_rate.png[A screenshot of the Maximum Transfer Rate dialog for a cluster.]
 
@@ -112,7 +112,7 @@ This setting does not affect the bandwidth allocated to any other clusters that 
 
 == Download a tiering report for your volumes
 
-You can download a report of the Tier Volumes page so you can review the tiering status of all the volumes on the clusters you are managing. Just click the image:button_download.png[Download] button. BlueXP tiering generates a .CSV file that you can review and send to other groups as needed. The .CSV file includes up to 10,000 rows of data.
+You can download a report of the Tier Volumes page so you can review the tiering status of all the volumes on the clusters you are managing. Just select the image:button_download.png[Download] button to download a .CSV file that you can review and send to other groups as needed. The .CSV file includes up to 10,000 rows of data.
 
 image:screenshot_tiering_report_download.png[A screenshot showing how to generate a CSV file listing the tiering status of all your volumes.]
 
@@ -120,7 +120,7 @@ image:screenshot_tiering_report_download.png[A screenshot showing how to generat
 
 Tiered data that is accessed from the cloud may be "re-heated" and moved back to the performance tier. However, if you want to proactively promote data to the performance tier from the cloud tier, you can do this in the _Tiering Policy_ dialog. This capability is available when using ONTAP 9.8 and greater.
 
-You might do this if you want to stop using tiering on a volume, or if you decide to keep all user data on the performance tier, but keep Snapshot copies on the cloud tier.
+You can do this if you want to stop using tiering on a volume, or if you decide to keep all user data on the performance tier, but keep Snapshot copies on the cloud tier.
 
 There are two options:
 
@@ -142,9 +142,9 @@ Make sure you have enough space in the performance tier for all the data that is
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click *Tier volumes* for the cluster.
+. From the *Clusters* page, select *Tier volumes* for the cluster.
 
-. Click the image:screenshot_edit_icon.gif[edit icon that appears at the end of each row in the table for tiering volumes] icon for the volume, choose the retrieval option you want to use, and click *Apply*.
+. Click the image:screenshot_edit_icon.gif[edit icon that appears at the end of each row in the table for tiering volumes] icon for the volume, choose the retrieval option you want to use, and select *Apply*.
 +
 image:screenshot_tiering_policy_settings_with_retrieve.png[A screenshot that shows the configurable tiering policy settings.]
 
@@ -154,7 +154,7 @@ The tiering policy is changed and the tiered data starts to be migrated back to 
 
 == Managing tiering settings on aggregates
 
-Each aggregate in your on-prem ONTAP systems has two settings that you can adjust: the tiering fullness threshold and whether inactive data reporting is enabled.
+Each aggregate in your on-premises ONTAP systems has two settings that you can adjust: the tiering fullness threshold and whether inactive data reporting is enabled.
 
 Tiering fullness threshold::
 Setting the threshold to a lower number reduces the amount of data required to be stored on the performance tier before tiering takes place. This might be useful for large aggregates that contain little active data.
@@ -168,11 +168,11 @@ TIP: It's best to keep IDR enabled because it helps to identify your inactive da
 
 .Steps
 
-. From the *Clusters* page, click *Advanced setup* for the selected cluster.
+. From the *Clusters* page, select *Advanced setup* for the selected cluster.
 +
 image:screenshot_tiering_advanced_setup_button.png[A screenshot showing the Advanced Setup button for a cluster.]
 
-. From the Advanced Setup page, click the menu icon for the aggregate and select *Modify Aggregate*.
+. From the Advanced Setup page, select the menu icon for the aggregate and select *Modify Aggregate*.
 +
 image:screenshot_tiering_modify_aggr.png["A screenshot showing the Modify Aggregate option for an aggregate."]
 
@@ -184,7 +184,7 @@ image:screenshot_tiering_modify_aggregate.png[A screenshot that shows a slider t
 
 == Fixing operational health
 
-Failures can happen. When they do, BlueXP tiering displays a "Failed" operational health status on the Cluster Dashboard. The health reflects the status of the ONTAP system and BlueXP.
+Failures can happen. When they do,  tiering displays a "Failed" operational health status on the Cluster Dashboard. The health reflects the status of the ONTAP system and BlueXP.
 
 .Steps
 
@@ -200,15 +200,15 @@ Failures can happen. When they do, BlueXP tiering displays a "Failed" operationa
 
 == Discovering additional clusters from BlueXP tiering
 
-You can add your undiscovered on-prem ONTAP clusters to BlueXP from the Tiering _Cluster_ page so that you can enable tiering for the cluster.
+You can add your undiscovered on-premises ONTAP clusters to BlueXP from the Tiering _Cluster_ page so that you can enable tiering for the cluster.
 
 Note that buttons also appear on the Tiering _On-Prem dashboard_ page for you to discover additional clusters.
 
 .Steps
 
-. From BlueXP tiering, click the *Clusters* tab.
+. Select the *Clusters* tab.
 
-. To see any undiscovered clusters, click *Show undiscovered clusters*.
+. To see any undiscovered clusters, select *Show undiscovered clusters*.
 +
 image:screenshot_tiering_show_undiscovered_cluster.png[A screenshot showing the Show Undiscovered Clusters button on the Tiering Dashboard.]
 +
@@ -218,32 +218,31 @@ If your NSS credentials are not saved in BlueXP, you are first prompted to add y
 +
 image:screenshot_tiering_discover_cluster.png[A screenshot showing how to discover an existing cluster to add to BlueXP and the Tiering Dashboard.]
 
-. Click *Discover Cluster* for the cluster that you want to manage through BlueXP and implement data tiering.
+. Select *Discover Cluster* for the cluster that you want to manage and implement data tiering.
 
-. In the _Cluster Details_ page, enter the password for the admin user account and click *Discover*.
+. In the _Cluster Details_ page, enter the password for the admin user account and select *Discover*.
 +
 Note that the cluster management IP address is populated based on information from your NSS account.
 
-. In the _Details & Credentials_ page the cluster name is added as the Working Environment Name, so just click *Go*.
+. In the _Details & Credentials_ page the cluster name is added as the Working Environment Name, so just select *Go*.
 
 .Result
 
-BlueXP discovers the cluster and adds it to a working environment in the Canvas using the cluster name as the working environment name.
+A working environment is created in the Canvas using the cluster name as the working environment name.
 
 You can enable the Tiering service or other services for this cluster in the right panel.
 
 == Search for a cluster across all BlueXP Connectors
 
-If you are using multiple Connectors to manage all the storage in your environment, some clusters on which you want to implement tiering may be in another Connector. If you are not sure which Connector is managing a certain cluster, you can search across all Connectors using BlueXP tiering.
+If you are using multiple Connectors to manage all the storage in your environment, some clusters on which you want to implement tiering may be associated with a different Connector. If you are not sure which Connector is managing a certain cluster, you can search across all Connectors.
 
 .Steps
 
-. In the BlueXP tiering menu bar, click the action menu and select *Search for cluster in all Connectors*.
+. In the BlueXP tiering menu bar, select the action menu and select *Search for cluster in all Connectors*.
 +
 image:screenshot_tiering_search for_cluster.png[A screenshot showing how to search for a cluster that may be in any of your BlueXP Connectors.]
 
-. In the displayed Search dialog, enter the name of the cluster and click *Search*.
-+
-BlueXP tiering displays the name of the Connector if it is able to find the cluster.
+. In the displayed Search dialog, enter the name of the cluster and select *Search*.
+
 
 . https://docs.netapp.com/us-en/bluexp-setup-admin/task-manage-multiple-connectors.html#switch-between-connectors[Switch to the Connector and configure tiering for the cluster^].

--- a/task-monitor-tiering-alerts.adoc
+++ b/task-monitor-tiering-alerts.adoc
@@ -13,9 +13,9 @@ summary: You can view the status of tiering alerts in the BlueXP Notification Ce
 :imagesdir: ./media/
 
 [.lead]
-You can view the status of tiering alerts in the BlueXP Notification Center. 
+You can view the status of tiering alerts in the Notification Center. 
 
-The Notification Center tracks the progress of tiering incidents so you can verify whether they have been resolved or not. You can display the notifications by clicking the (image:icon_bell.png[notification bell]) in the BlueXP menu bar. 
+The Notification Center tracks the progress of tiering incidents so you can verify whether they have been resolved or not. You can display the notifications by clicking the (image:icon_bell.png[notification bell]) in the menu bar. 
 
 At this time, there is one tiering event that will appear as a notification:
 
@@ -23,6 +23,6 @@ Tier additional data from cluster <name> to object storage to increase your stor
 
 This notification is a "Recommendation" to help make your systems more efficient and to save on storage costs. It indicates that a cluster is tiering less than 20% of its cold data - including clusters that are tiering no data. It provides a link to the https://bluexp.netapp.com/cloud-tiering-service-tco[BlueXP tiering total cost of ownership and savings calculator^] to help you calculate your cost savings.
 
-BlueXP does not send an email for this notification.
+You do not receive email for this notification.
 
 https://docs.netapp.com/us-en/bluexp-setup-admin/task-monitor-cm-operations.html[Learn more about the Notification Center^].

--- a/task-tiering-onprem-aws.adoc
+++ b/task-tiering-onprem-aws.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-tiering-onprem-aws.html
 keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, aws, amazon, s3
-summary: Free space on your on-prem ONTAP clusters by tiering inactive data to Amazon S3.
+summary: Free space on your on-premises ONTAP clusters by tiering inactive data to Amazon S3.
 ---
 
 = Tiering data from on-premises ONTAP clusters to Amazon S3
@@ -13,7 +13,7 @@ summary: Free space on your on-prem ONTAP clusters by tiering inactive data to A
 :imagesdir: ./media/
 
 [.lead]
-Free space on your on-prem ONTAP clusters by tiering inactive data to Amazon S3.
+Free space on your on-premises ONTAP clusters by tiering inactive data to Amazon S3.
 
 == Quick start
 
@@ -49,12 +49,12 @@ Discover your ONTAP cluster in BlueXP, verify that the cluster meets minimum req
 Set up permissions for the Connector to create and manage the S3 bucket. You'll also need to set up permissions for the on-premises ONTAP cluster so it can read and write data to the S3 bucket.
 
 [role="quick-margin-para"]
-<<Set up S3 permissions,See how to set up permissions for the Connector and for your on-prem cluster.>>
+<<Set up S3 permissions,See how to set up permissions for the Connector and for your on-premises cluster.>>
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-5.png[Five] Enable BlueXP tiering on the system
 
 [role="quick-margin-para"]
-Select an on-prem working environment, click *Enable* for the Tiering service, and follow the prompts to tier data to Amazon S3.
+Select an on-premises working environment, select  *Enable* for the Tiering service, and follow the prompts to tier data to Amazon S3.
 
 [role="quick-margin-para"]
 <<Tier inactive data from your first cluster to Amazon S3,See how to enable Tiering for your volumes.>>
@@ -65,7 +65,7 @@ Select an on-prem working environment, click *Enable* for the Tiering service, a
 After your free trial ends, pay for BlueXP tiering through a pay-as-you-go subscription, an ONTAP BlueXP tiering BYOL license, or a combination of both:
 
 [role="quick-margin-list"]
-* To subscribe from the AWS Marketplace, https://aws.amazon.com/marketplace/pp/prodview-oorxakq6lq7m4?sr=0-8&ref_=beagle&applicationId=AWSMPContessa[go to the BlueXP Marketplace offering^], click *Subscribe*, and then follow the prompts.
+* To subscribe from the AWS Marketplace, https://aws.amazon.com/marketplace/pp/prodview-oorxakq6lq7m4?sr=0-8&ref_=beagle&applicationId=AWSMPContessa[go to the BlueXP Marketplace offering^], select *Subscribe*, and then follow the prompts.
 * To pay using a BlueXP tiering BYOL license, mailto:ng-cloud-tiering@netapp.com?subject=Licensing[contact us if you need to purchase one], and then link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[add it to your account from the BlueXP digital wallet].
 
 == Network diagrams for connection options
@@ -204,7 +204,7 @@ https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 
 If you plan to use a standard public internet connection, then all the permissions are set by the Connector and there is nothing else you need to do. This type of connection is shown in the <<Network diagrams for connection options,first diagram above>>.
 
-If you want to have a more secure connection over the internet from your on-prem data center to the VPC, there's an option to select an AWS PrivateLink connection in the Tiering activation wizard. It's required if you plan to use a VPN or AWS Direct Connect to connect your on-premises system through a VPC Endpoint interface that uses a private IP address. This type of connection is shown in the <<Network diagrams for connection options,second diagram above>>.
+If you want to have a more secure connection over the internet from your on-premises data center to the VPC, there's an option to select an AWS PrivateLink connection in the Tiering activation wizard. It's required if you plan to use a VPN or AWS Direct Connect to connect your on-premises system through a VPC Endpoint interface that uses a private IP address. This type of connection is shown in the <<Network diagrams for connection options,second diagram above>>.
 
 . Create an Interface endpoint configuration using the Amazon VPC console or the command line. https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html[See details about using AWS PrivateLink for Amazon S3^].
 
@@ -255,31 +255,31 @@ After you prepare your AWS environment, start tiering inactive data from your fi
 
 .Steps
 
-. Select the on-prem ONTAP working environment.
+. Select the on-premises ONTAP working environment.
 
 . Click *Enable* for the Tiering service from the right panel.
 +
 If the Amazon S3 tiering destination exists as a working environment on the Canvas, you can drag the cluster onto the working environment to initiate the setup wizard.
 +
-image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable option that appears on the right side of the screen after you select an on-prem ONTAP working environment.]
+image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable option that appears on the right side of the screen after you select an on-premises ONTAP working environment.]
 
 . *Define Object Storage Name*: Enter a name for this object storage. It must be unique from any other object storage you may be using with aggregates on this cluster.
 
-. *Select Provider*: Select *Amazon Web Services* and click *Continue*.
+. *Select Provider*: Select *Amazon Web Services* and select *Continue*.
 +
 image:screenshot_tiering_aws_s3_bucket.png[A screenshot showing the data that must be provided to set up tiering to an S3 bucket.]
 
 . Complete the sections in the *Tiering Setup* page:
 
-.. *S3 Bucket*: Add a new S3 bucket or select an existing S3 bucket, select the bucket region, and click *Continue*.
+.. *S3 Bucket*: Add a new S3 bucket or select an existing S3 bucket, select the bucket region, and select *Continue*.
 +
-When using an on-prem Connector, you must enter the AWS Account ID that provides access to the existing S3 bucket or new S3 bucket that will be created.
+When using an on-premises Connector, you must enter the AWS Account ID that provides access to the existing S3 bucket or new S3 bucket that will be created.
 +
 The _fabric-pool_ prefix is used by default because the IAM policy for the Connector enables the instance to perform S3 actions on buckets named with that exact prefix. For example, you could name the S3 bucket _fabric-pool-AFF1_, where AFF1 is the name of the cluster. You can define the prefix for the buckets used for tiering as well. See <<Set up S3 permissions,setting up S3 permissions>> to make sure you have AWS permissions that recognize any custom prefix you plan to use. 
 
 .. *Storage Class*: BlueXP tiering manages the lifecycle transitions of your tiered data. Data starts in the _Standard_ class, but you can create a rule to apply a different storage class to the data after a certain number of days.
 +
-Select the S3 storage class that you want to transition the tiered data to and the number of days before the data is assigned to that class, and click *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Standard-IA_ class from the _Standard_ class after 45 days in object storage.
+Select the S3 storage class that you want to transition the tiered data to and the number of days before the data is assigned to that class, and select *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Standard-IA_ class from the _Standard_ class after 45 days in object storage.
 +
 If you choose *Keep data in this storage class*, then the data remains in the _Standard_ storage class and no rules are applied. link:reference-aws-support.html[See supported storage classes^].
 +
@@ -287,11 +287,11 @@ image:screenshot_tiering_lifecycle_selection_aws.png[A screenshot showing how to
 +
 Note that the lifecycle rule is applied to all objects in the selected bucket.
 
-.. *Credentials*: Enter the access key ID and secret key for an IAM user who has the required S3 permissions, and click *Continue*.
+.. *Credentials*: Enter the access key ID and secret key for an IAM user who has the required S3 permissions, and select *Continue*.
 +
 The IAM user must be in the same AWS account as the bucket that you selected or created on the *S3 Bucket* page.
 
-.. *Networking*: Enter the networking details and click *Continue*.
+.. *Networking*: Enter the networking details and select *Continue*.
 +
 Select the IPspace in the ONTAP cluster where the volumes you want to tier reside. The intercluster LIFs for this IPspace must have outbound internet access so that they can connect to your cloud provider's object storage.
 +
@@ -302,13 +302,13 @@ You can also set the network bandwidth available to upload inactive data to obje
 . On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and launch the Tiering Policy page:
 
 +
-* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and click *Configure volumes*.
-* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and click *Configure volumes*.
-* To select a single volume, click the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
+* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and select *Configure volumes*.
+* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and select *Configure volumes*.
+* To select a single volume, select the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
 +
 image:screenshot_tiering_initial_volumes.png["A screenshot that shows how to select a single volume, multiple volumes, or all volumes, and the modify selected volumes button."]
 
-. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and click *Apply*.
+. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +

--- a/task-tiering-onprem-azure.adoc
+++ b/task-tiering-onprem-azure.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-tiering-onprem-azure.html
 keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, azure, blob, azure blob
-summary: Free space on your on-prem ONTAP clusters by tiering inactive data to Azure Blob storage.
+summary: Free space on your on-premises ONTAP clusters by tiering inactive data to Azure Blob storage.
 ---
 
 = Tiering data from on-premises ONTAP clusters to Azure Blob storage
@@ -13,7 +13,7 @@ summary: Free space on your on-prem ONTAP clusters by tiering inactive data to A
 :imagesdir: ./media/
 
 [.lead]
-Free space on your on-prem ONTAP clusters by tiering inactive data to Azure Blob storage.
+Free space on your on-premises ONTAP clusters by tiering inactive data to Azure Blob storage.
 
 == Quick start
 
@@ -25,14 +25,14 @@ Get started quickly by following these steps, or scroll down to the remaining se
 You need the following:
 
 [role="quick-margin-list"]
-* An on-prem ONTAP cluster that's running ONTAP 9.4 or later and has an HTTPS connection to Azure Blob storage. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
+* An on-premises ONTAP cluster that's running ONTAP 9.4 or later and has an HTTPS connection to Azure Blob storage. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 * A Connector installed in an Azure VNet or on your premises.
 * Networking for a Connector that enables an outbound HTTPS connection to the ONTAP cluster in your data center, to Azure storage, and to the BlueXP tiering service.
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Set up tiering
 
 [role="quick-margin-para"]
-In BlueXP, select an on-prem ONTAP working environment, click *Enable* for the Tiering service, and follow the prompts to tier data to Azure Blob storage.
+In BlueXP, select an on-premises ONTAP working environment, select  *Enable* for the Tiering service, and follow the prompts to tier data to Azure Blob storage.
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-3.png[Three] Set up licensing
 
@@ -40,7 +40,7 @@ In BlueXP, select an on-prem ONTAP working environment, click *Enable* for the T
 After your free trial ends, pay for BlueXP tiering through a pay-as-you-go subscription, an ONTAP BlueXP tiering BYOL license, or a combination of both:
 
 [role="quick-margin-list"]
-* To subscribe from the Azure Marketplace, https://azuremarketplace.microsoft.com/en-us/marketplace/apps/netapp.cloud-manager?tab=Overview[go to the BlueXP Marketplace offering^], click *Subscribe*, and then follow the prompts.
+* To subscribe from the Azure Marketplace, https://azuremarketplace.microsoft.com/en-us/marketplace/apps/netapp.cloud-manager?tab=Overview[go to the BlueXP Marketplace offering^], select *Subscribe*, and then follow the prompts.
 * To pay using a BlueXP tiering BYOL license, mailto:ng-cloud-tiering@netapp.com?subject=Licensing[contact us if you need to purchase one], and then link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[add it to your account from the BlueXP digital wallet].
 
 == Requirements
@@ -85,7 +85,7 @@ NOTE: BlueXP tiering supports FlexGroup volumes, starting with ONTAP 9.5. Setup 
 
 === Discovering an ONTAP cluster
 
-You need to create an on-prem ONTAP working environment in BlueXP before you can start tiering cold data.
+You need to create an on-premises ONTAP working environment in BlueXP before you can start tiering cold data.
 
 https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 
@@ -106,7 +106,7 @@ If you created the Connector using an earlier version of BlueXP, then you'll nee
 
 === Preparing networking for the Connector
 
-Ensure that the Connector has the required networking connections. A Connector can be installed on-prem or in Azure.
+Ensure that the Connector has the required networking connections. A Connector can be installed on-premises or in Azure.
 
 .Steps
 
@@ -141,31 +141,31 @@ https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[An
 
 .Steps
 
-. Select the on-prem ONTAP working environment.
+. Select the on-premises ONTAP working environment.
 
 . Click *Enable* for the Tiering service from the right panel.
 +
 If the Azure Blob tiering destination exists as a working environment on the Canvas, you can drag the cluster onto the Azure Blob working environment to initiate the setup wizard.
 +
-image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable option that appears on the right side of the screen after you select an on-prem ONTAP working environment.]
+image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable option that appears on the right side of the screen after you select an on-premises ONTAP working environment.]
 
 . *Define Object Storage Name*: Enter a name for this object storage. It must be unique from any other object storage you may be using with aggregates on this cluster.
 
-. *Select Provider*: Select *Microsoft Azure* and click *Continue*.
+. *Select Provider*: Select *Microsoft Azure* and select *Continue*.
 
 . Complete the steps on the *Create Object Storage* pages:
 
-.. *Resource Group*: Select a resource group where an existing container is managed, or where you'd like to create a new container for tiered data, and click *Continue*.
+.. *Resource Group*: Select a resource group where an existing container is managed, or where you'd like to create a new container for tiered data, and select *Continue*.
 +
-When using an on-prem Connector, you must enter the Azure Subscription that provides access to the resource group.
+When using an on-premises Connector, you must enter the Azure Subscription that provides access to the resource group.
 
-.. *Azure Container*: Select the radio button to either add a new Blob container to a storage account or to use an existing container. Then select the storage account and choose the existing container, or enter the name for the new container. Then click *Continue*.
+.. *Azure Container*: Select the radio button to either add a new Blob container to a storage account or to use an existing container. Then select the storage account and choose the existing container, or enter the name for the new container. Then select *Continue*.
 +
 The storage accounts and containers that appear in this step belong to the resource group that you selected in the previous step.
 
 .. *Access Tier Lifecycle*: BlueXP tiering manages the lifecycle transitions of your tiered data. Data starts in the _Hot_ class, but you can create a rule to apply the _Cool_ class to the data after a certain number of days.
 +
-Select the access tier that you want to transition the tiered data to and the number of days before the data is assigned to that tier, and click *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Cool_ class from the _Hot_ class after 45 days in object storage.
+Select the access tier that you want to transition the tiered data to and the number of days before the data is assigned to that tier, and select *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Cool_ class from the _Hot_ class after 45 days in object storage.
 +
 If you choose *Keep data in this access tier*, then the data remains in the _Hot_ access tier and no rules are applied. link:reference-azure-support.html[See supported access tiers^].
 +
@@ -173,7 +173,7 @@ image:screenshot_tiering_lifecycle_selection_azure.png[A screenshot showing how 
 +
 Note that the lifecycle rule is applied to all blob containers in the selected storage account.
 
-.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage, and click *Continue*.
+.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage, and select *Continue*.
 +
 Selecting the correct IPspace ensures that BlueXP tiering can set up a connection from ONTAP to your cloud provider's object storage.
 +
@@ -182,13 +182,13 @@ You can also set the network bandwidth available to upload inactive data to obje
 . On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and launch the Tiering Policy page:
 
 +
-* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and click *Configure volumes*.
-* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and click *Configure volumes*.
-* To select a single volume, click the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
+* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and select *Configure volumes*.
+* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and select *Configure volumes*.
+* To select a single volume, select the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
 +
 image:screenshot_tiering_initial_volumes.png[A screenshot that shows how to select a single volume, multiple volumes, or all volumes, and the modify selected volumes button.]
 
-. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and click *Apply*.
+. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +

--- a/task-tiering-onprem-gcp.adoc
+++ b/task-tiering-onprem-gcp.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-tiering-onprem-gcp.html
 keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, google, gcp, google cloud storage
-summary: Free space on your on-prem ONTAP clusters by tiering inactive data to Google Cloud Storage.
+summary: Free space on your on-premises ONTAP clusters by tiering inactive data to Google Cloud Storage.
 ---
 
 = Tiering data from on-premises ONTAP clusters to Google Cloud Storage
@@ -13,7 +13,7 @@ summary: Free space on your on-prem ONTAP clusters by tiering inactive data to G
 :imagesdir: ./media/
 
 [.lead]
-Free space on your on-prem ONTAP clusters by tiering inactive data to Google Cloud Storage.
+Free space on your on-premises ONTAP clusters by tiering inactive data to Google Cloud Storage.
 
 == Quick start
 
@@ -25,7 +25,7 @@ Get started quickly by following these steps, or scroll down to the remaining se
 You need the following:
 
 [role="quick-margin-list"]
-* An on-prem ONTAP cluster that's running ONTAP 9.6 or later and has an HTTPS connection to Google Cloud Storage. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
+* An on-premises ONTAP cluster that's running ONTAP 9.6 or later and has an HTTPS connection to Google Cloud Storage. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 * A service account that has the predefined Storage Admin role and storage access keys.
 * A Connector installed in a Google Cloud Platform VPC.
 * Networking for the Connector that enables an outbound HTTPS connection to the ONTAP cluster in your data center, to Google Cloud Storage, and to the BlueXP tiering service.
@@ -33,7 +33,7 @@ You need the following:
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Set up tiering
 
 [role="quick-margin-para"]
-In BlueXP, select an on-prem working environment, click *Enable* for the Tiering service, and follow the prompts to tier data to Google Cloud Storage.
+In BlueXP, select an on-premises working environment, select *Enable* for the Tiering service, and follow the prompts to tier data to Google Cloud Storage.
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-3.png[Three] Set up licensing
 
@@ -41,7 +41,7 @@ In BlueXP, select an on-prem working environment, click *Enable* for the Tiering
 After your free trial ends, pay for BlueXP tiering through a pay-as-you-go subscription, an ONTAP BlueXP tiering BYOL license, or a combination of both:
 
 [role="quick-margin-list"]
-* To subscribe from the GCP Marketplace, https://console.cloud.google.com/marketplace/details/netapp-cloudmanager/cloud-manager?supportedpurview=project&rif_reserved[go to the BlueXP Marketplace offering^], click *Subscribe*, and then follow the prompts.
+* To subscribe from the GCP Marketplace, https://console.cloud.google.com/marketplace/details/netapp-cloudmanager/cloud-manager?supportedpurview=project&rif_reserved[go to the BlueXP Marketplace offering^], select *Subscribe*, and then follow the prompts.
 * To pay using a BlueXP tiering BYOL license, mailto:ng-cloud-tiering@netapp.com?subject=Licensing[contact us if you need to purchase one], and then link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[add it to your account from the BlueXP digital wallet^].
 
 == Requirements
@@ -86,7 +86,7 @@ NOTE: BlueXP tiering supports FlexGroup volumes. Setup works the same as any oth
 
 === Discovering an ONTAP cluster
 
-You need to create an on-prem ONTAP working environment in BlueXP before you can start tiering cold data.
+You need to create an on-premises ONTAP working environment in BlueXP before you can start tiering cold data.
 
 https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 
@@ -127,9 +127,9 @@ NOTE: If you are planning to configure BlueXP tiering to use lower cost storage 
 
 . Go to https://console.cloud.google.com/storage/settings[GCP Storage Settings^] and create access keys for the service account:
 
-.. Select a project, and click *Interoperability*. If you haven't already done so, click *Enable interoperability access*.
+.. Select a project, and select *Interoperability*. If you haven't already done so, select *Enable interoperability access*.
 
-.. Under *Access keys for service accounts*, click *Create a key for a service account*, select the service account that you just created, and click *Create Key*.
+.. Under *Access keys for service accounts*, select *Create a key for a service account*, select the service account that you just created, and select *Create Key*.
 +
 You'll need to enter the keys later when you set up BlueXP tiering.
 
@@ -144,17 +144,17 @@ After you prepare your Google Cloud environment, start tiering inactive data fro
 
 .Steps
 
-. Select the on-prem ONTAP working environment.
+. Select the on-premises ONTAP working environment.
 
 . Click *Enable* for the Tiering service from the right panel.
 +
 If the Google Cloud Storage tiering destination exists as a working environment on the Canvas, you can drag the cluster onto the Google Cloud Storage working environment to initiate the setup wizard.
 +
-image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable option that appears on the right side of the screen after you select an on-prem ONTAP working environment.]
+image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable option that appears on the right side of the screen after you select an on-premises ONTAP working environment.]
 
 . *Define Object Storage Name*: Enter a name for this object storage. It must be unique from any other object storage you may be using with aggregates on this cluster.
 
-. *Select Provider*: Select *Google Cloud* and click *Continue*.
+. *Select Provider*: Select *Google Cloud* and select *Continue*.
 
 . Complete the steps on the *Create Object Storage* pages:
 
@@ -162,7 +162,7 @@ image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Enable opt
 
 .. *Storage Class Lifecycle*: BlueXP tiering manages the lifecycle transitions of your tiered data. Data starts in the _Standard_ class, but you can create rules to apply different storage classes after a certain number of days.
 +
-Select the Google Cloud storage class that you want to transition the tiered data to and the number of days before the data is assigned to that class, and click *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Nearline_ class from the _Standard_ class after 30 days in object storage, and then to the _Coldline_ class after 60 days in object storage.
+Select the Google Cloud storage class that you want to transition the tiered data to and the number of days before the data is assigned to that class, and select *Continue*. For example, the screenshot below shows that tiered data is assigned to the _Nearline_ class from the _Standard_ class after 30 days in object storage, and then to the _Coldline_ class after 60 days in object storage.
 +
 If you choose *Keep data in this storage class*, then the data remains in the that storage class. link:reference-google-support.html[See supported storage classes^].
 +
@@ -183,13 +183,13 @@ You can also set the network bandwidth available to upload inactive data to obje
 . On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and launch the Tiering Policy page:
 
 +
-* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and click *Configure volumes*.
-* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and click *Configure volumes*.
-* To select a single volume, click the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
+* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and select *Configure volumes*.
+* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and select *Configure volumes*.
+* To select a single volume, select the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
 +
 image:screenshot_tiering_initial_volumes.png[A screenshot that shows how to select a single volume, multiple volumes, or all volumes, and the modify selected volumes button.]
 
-. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and click *Apply*.
+. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +

--- a/task-tiering-onprem-overview.adoc
+++ b/task-tiering-onprem-overview.adoc
@@ -13,13 +13,13 @@ summary: BlueXP tiering provides an aggregated view of data tiering from each of
 :imagesdir: ./media/
 
 [.lead]
-BlueXP tiering provides an aggregated view of data tiering from each of your on-premises clusters. This overview provides a clear picture of your environment and enables you to take proper actions.
+BlueXP tiering provides an aggregated view of data tiering from each of your on-premises clusters. 
 
-Just click *Tiering > On-Premises Dashboard*. BlueXP tiering provides the following details about your environment.
+Select *Tiering > On-Premises Dashboard*. The following details are included on the dashboard.
 
 image:screenshot_tiering_onprem_dashboard.png[A screenshot of the On-Premises Dashboard page.]
 
-Discovered clusters:: The number of on-premises clusters that BlueXP tiering has discovered. The chart provides an overview of the tiering status for these clusters.
+Discovered clusters:: The number of on-premises clusters that have been discovered. The chart provides an overview of the tiering status for these clusters.
 +
 * High tiering - Clusters that are tiering over 20% of their cold data
 * Low tiering - Clusters that are tiering less than 20% of their cold data

--- a/task-tiering-onprem-s3-compat.adoc
+++ b/task-tiering-onprem-s3-compat.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-tiering-onprem-s3-compat.html
 keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, s3, tier to s3, minio
-summary: Free space on your on-prem ONTAP clusters by tiering inactive data to any Object Storage service which uses the Simple Storage Service (S3) protocol.
+summary: Free space on your on-premises ONTAP clusters by tiering inactive data to any Object Storage service which uses the Simple Storage Service (S3) protocol.
 ---
 
 = Tiering data from on-premises ONTAP clusters to S3 object storage
@@ -13,7 +13,7 @@ summary: Free space on your on-prem ONTAP clusters by tiering inactive data to a
 :imagesdir: ./media/
 
 [.lead]
-Free space on your on-prem ONTAP clusters by tiering inactive data to any object storage service which uses the Simple Storage Service (S3) protocol.
+Free space on your on-premises ONTAP clusters by tiering inactive data to any object storage service which uses the Simple Storage Service (S3) protocol.
 
 At this time, MinIO object storage has been qualified.
 
@@ -34,7 +34,7 @@ Get started quickly by following these steps, or scroll down to the remaining se
 You need the following:
 
 [role="quick-margin-list"]
-* A source on-prem ONTAP cluster that's running ONTAP 9.8 or later, and a connection over a user-specified port to the destination S3-compatible object storage. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
+* A source on-premises ONTAP cluster that's running ONTAP 9.8 or later, and a connection over a user-specified port to the destination S3-compatible object storage. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 * The FQDN, Access Key, and Secret Key for the object storage server so that the ONTAP cluster can access the bucket.
 * A Connector installed on your premises.
 * Networking for the Connector that enables an outbound HTTPS connection to the source ONTAP cluster, to the S3-compatible object storage, and to the BlueXP tiering service.
@@ -42,17 +42,17 @@ You need the following:
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Set up tiering
 
 [role="quick-margin-para"]
-In BlueXP, select an on-prem working environment, click *Enable* for the Tiering service, and follow the prompts to tier data to S3-compatible object storage.
+In BlueXP, select an on-premises working environment, select *Enable* for the Tiering service, and follow the prompts to tier data to S3-compatible object storage.
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-3.png[Three] Set up licensing
 
 [role="quick-margin-para"]
-Pay for BlueXP tiering through a pay-as-you-go subscription from your cloud provider, a NetApp BlueXP tiering bring-your-own-license, or a combination of both:
+Pay for tiering through a pay-as-you-go subscription from your cloud provider, a NetApp tiering bring-your-own-license, or a combination of both:
 
 [role="quick-margin-list"]
-* To subscribe to the BlueXP PAYGO offering from the https://aws.amazon.com/marketplace/pp/prodview-oorxakq6lq7m4?sr=0-8&ref_=beagle&applicationId=AWSMPContessa[AWS Marketplace^], https://azuremarketplace.microsoft.com/en-us/marketplace/apps/netapp.cloud-manager?tab=Overview[Azure Marketplace^], or https://console.cloud.google.com/marketplace/details/netapp-cloudmanager/cloud-manager?supportedpurview=project&rif_reserved[GCP Marketplace^], click *Subscribe* and follow the prompts.
+* To subscribe to the BlueXP PAYGO offering from the https://aws.amazon.com/marketplace/pp/prodview-oorxakq6lq7m4?sr=0-8&ref_=beagle&applicationId=AWSMPContessa[AWS Marketplace^], https://azuremarketplace.microsoft.com/en-us/marketplace/apps/netapp.cloud-manager?tab=Overview[Azure Marketplace^], or https://console.cloud.google.com/marketplace/details/netapp-cloudmanager/cloud-manager?supportedpurview=project&rif_reserved[GCP Marketplace^], select *Subscribe* and follow the prompts.
 
-* To pay using a BlueXP tiering BYOL license, mailto:ng-cloud-tiering@netapp.com?subject=Licensing[contact us if you need to purchase one], and then link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[add it to your account from the BlueXP digital wallet^].
+* To pay using a tiering BYOL license, mailto:ng-cloud-tiering@netapp.com?subject=Licensing[contact us if you need to purchase one], and then link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[add it to your account from the digital wallet^].
 .
 
 == Requirements
@@ -94,7 +94,7 @@ TIP: BlueXP tiering supports both FlexVol and FlexGroup volumes.
 
 === Discovering an ONTAP cluster
 
-You need to create an on-prem ONTAP working environment in the BlueXP Canvas before you can start tiering cold data.
+You need to create an on-premises ONTAP working environment before you can start tiering cold data.
 
 https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 
@@ -147,48 +147,45 @@ After you prepare your environment, start tiering inactive data from your first 
 
 .Steps
 
-. Select the on-prem ONTAP working environment.
+. Select the on-premises ONTAP working environment.
 
-. Click *Enable* for the Tiering service from the right panel.
+. Select *Enable* for the Tiering service from the right panel.
 +
-image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Tiering option that appears on the right side of the screen after you select an on-prem ONTAP working environment.]
+image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Tiering option that appears on the right side of the screen after you select an on-premises ONTAP working environment.]
 
 . *Define Object Storage Name*: Enter a name for this object storage. It must be unique from any other object storage you may be using with aggregates on this cluster.
 
-. *Select Provider*: Select *S3 Compatible* and click *Continue*.
+. *Select Provider*: Select *S3 Compatible* and select *Continue*.
 
 . Complete the steps on the *Create Object Storage* pages:
 
 .. *Server*: Enter the FQDN of the S3-compatible object storage server, the port that ONTAP should use for HTTPS communication with the server, and the access key and secret key for an account that has the required S3 permissions.
 
-.. *Bucket*: Add a new bucket or select an existing bucket and click *Continue*.
+.. *Bucket*: Add a new bucket or select an existing bucket and select *Continue*.
 
-.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage and click *Continue*.
+.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage and select *Continue*.
 +
 Selecting the correct IPspace ensures that BlueXP tiering can set up a connection from ONTAP to your S3-compatible object storage.
 +
 You can also set the network bandwidth available to upload inactive data to object storage by defining the "Maximum transfer rate". Select the *Limited* radio button and enter the maximum bandwidth that can be used, or select *Unlimited* to indicate that there is no limit.
 
-. On the _Success_ page click *Continue* to set up your volumes now.
+. On the _Success_ page select *Continue* to set up your volumes now.
 
-. On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and click *Continue*:
+. On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and select *Continue*:
 
 +
-* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and click *Configure volumes*.
-* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and click *Configure volumes*.
-* To select a single volume, click the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
+* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and select *Configure volumes*.
+* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and select *Configure volumes*.
+* To select a single volume, select the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
 +
 image:screenshot_tiering_initial_volumes.png["A screenshot that shows how to select a single volume, multiple volumes, or all volumes, and the modify selected volumes button."]
 
-. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and click *Apply*.
+. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +
 image:screenshot_tiering_initial_policy_settings.png[A screenshot that shows the configurable tiering policy settings.]
 
-.Result
-
-You've successfully set up data tiering from volumes on the cluster to S3-compatible object storage.
 
 .What's next?
 

--- a/task-tiering-onprem-storagegrid.adoc
+++ b/task-tiering-onprem-storagegrid.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-tiering-onprem-storagegrid.html
 keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, storagegrid, tier to storagegrid, fabricpool storagegrid
-summary: Free space on your on-prem ONTAP clusters by tiering inactive data to StorageGRID.
+summary: Free space on your on-premises ONTAP clusters by tiering inactive data to StorageGRID.
 ---
 
 = Tiering data from on-premises ONTAP clusters to StorageGRID
@@ -13,7 +13,7 @@ summary: Free space on your on-prem ONTAP clusters by tiering inactive data to S
 :imagesdir: ./media/
 
 [.lead]
-Free space on your on-prem ONTAP clusters by tiering inactive data to StorageGRID.
+Free space on your on-premises ONTAP clusters by tiering inactive data to StorageGRID.
 
 == Quick start
 
@@ -25,7 +25,7 @@ Get started quickly by following these steps, or scroll down to the remaining se
 You need the following:
 
 [role="quick-margin-list"]
-* An on-prem ONTAP cluster that's running ONTAP 9.4 or later, and a connection over a user-specified port to StorageGRID. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
+* An on-premises ONTAP cluster that's running ONTAP 9.4 or later, and a connection over a user-specified port to StorageGRID. https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 * StorageGRID 10.3 or later with AWS access keys that have S3 permissions.
 * A Connector installed on your premises.
 * Networking for the Connector that enables an outbound HTTPS connection to the ONTAP cluster, to StorageGRID, and to the BlueXP tiering service.
@@ -33,7 +33,7 @@ You need the following:
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Set up tiering
 
 [role="quick-margin-para"]
-In BlueXP, select an on-prem working environment, click *Enable* for the Tiering service, and follow the prompts to tier data to StorageGRID.
+Select an on-premises working environment, select *Enable* for the Tiering service, and follow the prompts to tier data to StorageGRID.
 
 == Requirements
 
@@ -57,7 +57,7 @@ Supported ONTAP version::
 ONTAP 9.4 or later
 
 Licensing::
-A BlueXP tiering license isn't required in your BlueXP organization, nor is a FabricPool license required on the ONTAP cluster, when tiering data to StorageGRID.
+If you are tiering data to StorageGRID, you don't need a license for tiering or a FabricPool license.
 
 Cluster networking requirements::
 * The ONTAP cluster initiates an HTTPS connection over a user-specified port to the StorageGRID Gateway Node (the port is configurable during tiering setup).
@@ -70,7 +70,7 @@ A connection between the cluster and the BlueXP tiering service is not required.
 
 * An intercluster LIF is required on each ONTAP node that hosts the volumes you want to tier. The LIF must be associated with the _IPspace_ that ONTAP should use to connect to object storage.
 +
-When you set up data tiering, BlueXP tiering prompts you for the IPspace to use. You should choose the IPspace that each LIF is associated with. That might be the "Default" IPspace or a custom IPspace that you created. Learn more about https://docs.netapp.com/us-en/ontap/networking/create_a_lif.html[LIFs^] and https://docs.netapp.com/us-en/ontap/networking/standard_properties_of_ipspaces.html[IPspaces^].
+When you set up data tiering, you're prompted for the IPspace to use. You should choose the IPspace that each LIF is associated with. That might be the "Default" IPspace or a custom IPspace that you created. Learn more about https://docs.netapp.com/us-en/ontap/networking/create_a_lif.html[LIFs^] and https://docs.netapp.com/us-en/ontap/networking/standard_properties_of_ipspaces.html[IPspaces^].
 
 include::_include/tiering_supported_volumes.adoc[]
 
@@ -78,7 +78,7 @@ NOTE: BlueXP tiering supports FlexGroup volumes, starting with ONTAP 9.5. Setup 
 
 === Discovering an ONTAP cluster
 
-You need to create an on-prem ONTAP working environment in the BlueXP Canvas before you can start tiering cold data.
+You need to create an on-premises ONTAP working environment in the Canvas before you can start tiering cold data.
 
 https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Learn how to discover a cluster^].
 
@@ -137,27 +137,27 @@ After you prepare your environment, start tiering inactive data from your first 
 
 .Steps
 
-. Select the on-prem ONTAP working environment.
+. Select the on-premises ONTAP working environment.
 
 . Click *Enable* for the Tiering service from the right panel.
 +
 If the StorageGRID tiering destination exists as a working environment on the Canvas, you can drag the cluster onto the StorageGRID working environment to initiate the setup wizard.
 +
-image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Setup Tiering option that appears on the right side of the screen after you select an on-prem ONTAP working environment.]
+image:screenshot_setup_tiering_onprem.png[A screenshot that shows the Setup Tiering option that appears on the right side of the screen after you select an on-premises ONTAP working environment.]
 
 . *Define Object Storage Name*: Enter a name for this object storage. It must be unique from any other object storage you may be using with aggregates on this cluster.
 
-. *Select Provider*: Select *StorageGRID* and click *Continue*.
+. *Select Provider*: Select *StorageGRID* and select *Continue*.
 
 . Complete the steps on the *Create Object Storage* pages:
 
 .. *Server*: Enter the FQDN of the StorageGRID Gateway Node, the port that ONTAP should use for HTTPS communication with StorageGRID, and the access key and secret key for an account that has the required S3 permissions.
 
-.. *Bucket*: Add a new bucket or select an existing bucket that starts with the prefix _fabric-pool_ and click *Continue*.
+.. *Bucket*: Add a new bucket or select an existing bucket that starts with the prefix _fabric-pool_ and select *Continue*.
 +
 The _fabric-pool_ prefix is required because the IAM policy for the Connector enables the instance to perform S3 actions on buckets named with that exact prefix. For example, you could name the S3 bucket _fabric-pool-AFF1_, where AFF1 is the name of the cluster.
 
-.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage and click *Continue*.
+.. *Cluster Network*: Select the IPspace that ONTAP should use to connect to object storage and select *Continue*.
 +
 Selecting the correct IPspace ensures that BlueXP tiering can set up a connection from ONTAP to StorageGRID object storage.
 +
@@ -166,21 +166,18 @@ You can also set the network bandwidth available to upload inactive data to obje
 . On the _Tier Volumes_ page, select the volumes that you want to configure tiering for and launch the Tiering Policy page:
 
 +
-* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and click *Configure volumes*.
-* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and click *Configure volumes*.
-* To select a single volume, click the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
+* To select all volumes, check the box in the title row (image:button_backup_all_volumes.png[""]) and select *Configure volumes*.
+* To select multiple volumes, check the box for each volume (image:button_backup_1_volume.png[""]) and select *Configure volumes*.
+* To select a single volume, select the row (or image:screenshot_edit_icon.gif[edit pencil icon] icon) for the volume.
 +
 image:screenshot_tiering_initial_volumes.png[A screenshot that shows how to select a single volume, multiple volumes, or all volumes, and the modify selected volumes button.]
 
-. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and click *Apply*.
+. In the _Tiering Policy_ dialog, select a tiering policy, optionally adjust the cooling days for the selected volumes, and select *Apply*.
 +
 link:concept-cloud-tiering.html#volume-tiering-policies[Learn more about volume tiering policies and cooling days].
 +
 image:screenshot_tiering_initial_policy_settings.png[A screenshot that shows the configurable tiering policy settings.]
 
-.Result
-
-You've successfully set up data tiering from volumes on the cluster to StorageGRID.
 
 .What's next?
 

--- a/task-tiering-test.adoc
+++ b/task-tiering-test.adoc
@@ -27,9 +27,9 @@ It's best to run this check when the cluster is under 50% CPU utilization.
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click the menu icon for a cluster and select *Cloud Performance Test*.
+. From the *Clusters* page, select the menu icon for a cluster and select *Cloud Performance Test*.
 
-. Review the details and click *Continue*.
+. Review the details and select *Continue*.
 
 . Follow the prompts to provide the required information.
 +
@@ -41,7 +41,7 @@ The information that you need to provide is the same as if you were setting up t
 
 . From the left navigation menu, select *Mobility > Tiering*.
 
-. From the *Clusters* page, click the menu icon for a cluster and select *Cloud Performance Test*.
+. From the *Clusters* page, select the menu icon for a cluster and select *Cloud Performance Test*.
 
 . Select a node from the drop-down list.
 

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -60,7 +60,7 @@ See the full list of endpoints for your https://docs.netapp.com/us-en/bluexp-set
 
 === Drag and drop to enable tiering to additional destinations
 
-If the Azure Blob, Google Cloud Storage, or StorageGRID tiering destination exists as a working environment on the Canvas, you can drag your on-prem ONTAP working environment onto the destination to initiate the Tiering setup wizard.
+If the Azure Blob, Google Cloud Storage, or StorageGRID tiering destination exists as a working environment on the Canvas, you can drag your on-premises ONTAP working environment onto the destination to initiate the Tiering setup wizard.
 
 == 19 September 2022
 
@@ -72,7 +72,7 @@ https://docs.netapp.com/us-en/bluexp-tiering/task-tiering-onprem-aws.html[Review
 
 === Drag and drop to enable tiering to Amazon S3
 
-If the Amazon S3 tiering destination exists as a working environment on the Canvas, you can drag your on-prem ONTAP working environment onto the destination to initiate the Tiering setup wizard.
+If the Amazon S3 tiering destination exists as a working environment on the Canvas, you can drag your on-premises ONTAP working environment onto the destination to initiate the Tiering setup wizard.
 
 === Choose tiering behavior when removing mirror object store
 


### PR DESCRIPTION
This pull request focuses on improving terminology consistency across documentation files by replacing "on-prem" with "on-premises" and refining phrasing for clarity. Additionally, it updates subscription-related terminology and enhances instructions for licensing and tiering workflows.

### Terminology Improvements:
* Replaced "on-prem" with "on-premises" across multiple files to ensure consistency and accuracy in documentation. (`_index.yml` [[1]](diffhunk://#diff-eeb91e423bf43be21fa638d740fc3019a84e78a15a5f858410a25042d111d6b6L15-R15) `concept-cloud-tiering.adoc` [[2]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L18-R20) [[3]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L30-R32) [[4]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L111-R113) [[5]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L129-R131) `faq-cloud-tiering.adoc` [[6]](diffhunk://#diff-ef63287cd4d4ecd773856cadd9bbf62f8761b078157b1a15e93f32951c2fe577L106-R114) [[7]](diffhunk://#diff-ef63287cd4d4ecd773856cadd9bbf62f8761b078157b1a15e93f32951c2fe577L124-R124) [[8]](diffhunk://#diff-ef63287cd4d4ecd773856cadd9bbf62f8761b078157b1a15e93f32951c2fe577L231-R231) `project.yml` [[9]](diffhunk://#diff-4f3430205157bae48d1786fcd16dbaaa50f9a1dc46b93ff9ccd26487c269b317L20-R20) `reference-google-support.adoc` [[10]](diffhunk://#diff-fdeeb069302177b16f8ff187835e237630068e6faf05d7643062c4c77ee63969L20-R34) `task-managing-object-storage.adoc` [[11]](diffhunk://#diff-fd52c38890c704a249a84b7bbe7e203358aa7dc1ad65b5293ed59ac8a8ecdf2bL5-R5)

### Subscription and Licensing Updates:
* Updated references to "BlueXP tiering" to "NetApp Intelligent Services tiering" and adjusted related subscription instructions for clarity. (`task-licensing-cloud-tiering.adoc` [[1]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L20-R36) [[2]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L46-R48) [[3]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L62-R64) [[4]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L78-R80) [[5]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L90-R90) [[6]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L100-R109) [[7]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L180-R184)

### Instruction Refinements:
* Improved phrasing in step-by-step instructions for subscribing and deploying licenses, replacing "click" with "select" for consistency in terminology. (`task-licensing-cloud-tiering.adoc` [[1]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L46-R48) [[2]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L62-R64) [[3]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L78-R80) [[4]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L180-R184)

These changes enhance the clarity, consistency, and professionalism of the documentation, ensuring it aligns with industry standards and user expectations.